### PR TITLE
CI

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -1,0 +1,55 @@
+on: [push, pull_request]
+
+jobs:
+  check_java_latest:
+    runs-on: ubuntu-latest
+    name: Java 16
+    
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 16
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-jdk16-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-jdk16
+            
+      - name: Compile with Gradle
+        run: ./gradlew assemble
+
+
+  
+  check_java8:
+    runs-on: ubuntu-latest
+    name: Java 8
+    
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-jdk8-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-jdk8
+            
+      - name: Compile with Gradle
+        run: ./gradlew assemble
+  
+      - name: Test
+        run: ./gradlew check

--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -3,14 +3,14 @@ on: [push, pull_request]
 jobs:
   check_java_latest:
     runs-on: ubuntu-latest
-    name: Java 16
+    name: Java 15
     
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 16
+          java-version: 15
 
       - name: Gradle cache
         uses: actions/cache@v2
@@ -18,9 +18,9 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-jdk16-${{ hashFiles('**/*.gradle*') }}
+          key: ${{ runner.os }}-gradle-jdk15-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-jdk16
+            ${{ runner.os }}-gradle-jdk15
             
       - name: Compile with Gradle
         run: ./gradlew assemble

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+# run deploy only when pushing new tags
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-jdk8-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-jdk8
+            
+      - name: Create Artifacts
+        run: ./gradlew assemble
+        # just to ensure it compiles; if it doesn't then don't continue
+
+      - name: Configure GPG Key and Properties
+        # see https://stackoverflow.com/a/61748039 for how the key was exported
+        run: |
+          mkdir -p ~/.gnupg/
+          echo -n "$GPG_SIGNING_KEY" | base64 --decode > ~/.gnupg/private.key
+          gpg --import ~/.gnupg/private.key
+
+          echo signing.keyId=$SIGNING_KEY_ID >> gradle.properties
+          echo signing.password=$SIGNING_PASSWORD >> gradle.properties
+          echo signing.secretKeyRingFile=`ls ~/.gnupg/secring.gpg` >> gradle.properties
+          echo ossrhUsername=$MAVEN_USERNAME >> gradle.properties
+          echo ossrhPassword=$MAVEN_PASSWORD >> gradle.properties
+
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+
+
+      - name: Publish package
+        run: ./gradlew publish

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
         run: ./gradlew assemble
         # just to ensure it compiles; if it doesn't then don't continue
 
-      - name: Configure GPG Key Properties
+      - name: Configure Signing Key
         run: |
           echo signingKey=$SIGNING_KEY >> gradle.properties
           echo signingPassword=$SIGNING_PASSWORD >> gradle.properties

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,22 +29,15 @@ jobs:
         run: ./gradlew assemble
         # just to ensure it compiles; if it doesn't then don't continue
 
-      - name: Configure GPG Key and Properties
-        # see https://stackoverflow.com/a/61748039 for how the key was exported
+      - name: Configure GPG Key Properties
         run: |
-          mkdir -p ~/.gnupg/
-          echo -n "$GPG_SIGNING_KEY" | base64 --decode > ~/.gnupg/private.key
-          gpg --import ~/.gnupg/private.key
-
-          echo signing.keyId=$SIGNING_KEY_ID >> gradle.properties
-          echo signing.password=$SIGNING_PASSWORD >> gradle.properties
-          echo signing.secretKeyRingFile=`ls ~/.gnupg/secring.gpg` >> gradle.properties
+          echo signingKey=$SIGNING_KEY >> gradle.properties
+          echo signingPassword=$SIGNING_PASSWORD >> gradle.properties
           echo ossrhUsername=$MAVEN_USERNAME >> gradle.properties
           echo ossrhPassword=$MAVEN_PASSWORD >> gradle.properties
 
         env:
-          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ To install the current working version to your local Maven repo, run
 ./gradlew publishToMavenLocal
 ```
 
+### Publishing New Versions
+
+To publish new versions to Maven Central, first update the version in `build.gradle`:
+```
+def mavenVersion = '0.0.1'
+```
+Then tag the version as appropriate in GitHub, for example:
+```sh
+git tag v0.0.1
+git push origin v0.0.1
+```
+
+The CI process `deploy.yml` will run to publish the new version.
+
+Coordinate with [@dehall](https://github.com/dehall) (dehall@mitre.org) to ensure the published artifacts are released. 
+
 
 # License
 Copyright 2021 The MITRE Corporation

--- a/build.gradle
+++ b/build.gradle
@@ -117,5 +117,5 @@ signing {
   def signingKey = findProperty("signingKey")
   def signingPassword = findProperty("signingPassword")
   useInMemoryPgpKeys(signingKey, signingPassword)
-  sign publishing.publications.smartBackendAuth
+  sign publishing.publications.processMessageOperation
 }

--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,8 @@ publishing {
 }
 
 signing {
-  required { project.hasProperty('signing.keyId') }
-  sign publishing.publications.processMessageOperation
+  def signingKey = findProperty("signingKey")
+  def signingPassword = findProperty("signingPassword")
+  useInMemoryPgpKeys(signingKey, signingPassword)
+  sign publishing.publications.smartBackendAuth
 }


### PR DESCRIPTION
GitHub actions for building & testing on PRs, and deploys to Maven Central when a new tag is pushed.

Note there are repo secrets configured for the GPG key and passphrase, and sonatype username and password. The GPG key needs to be one that is published and available -- see the Maven Central repo guide for more information.

Unfortunately even if this "works" there are some issues with publishing to maven central that we need to be aware of. 
1. Pushing the release artifacts could time out: https://github.com/mcode/process-message-operation/runs/2412418956?check_suite_focus=true
2. Pushing the release artifacts could result in multiple "staging repos" being created and things don't work quite right. See `https://github.com/gradle/gradle/issues/5711`

I'm thinking that even if the process isn't perfect, we will be pushing new releases infrequently enough that if it goes well, great, if not, we just publish manually and it's not a big deal. Open to other opinions.