### PR TITLE
Don't sign unless signingKey is present

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,7 @@ publishing {
 }
 
 signing {
+  required { project.hasProperty('signingKey') }
   def signingKey = findProperty("signingKey")
   def signingPassword = findProperty("signingPassword")
   useInMemoryPgpKeys(signingKey, signingPassword)


### PR DESCRIPTION
quick fix to ensure that the library can still `publishToMavenLocal` even without a signing key present